### PR TITLE
Inclusion of a new column to act table

### DIFF
--- a/data/Act.csv
+++ b/data/Act.csv
@@ -1,11 +1,10 @@
-act_ID,agent,action,agens,start,end,substantial_discussion,comment,source_id,page_number,created,created_by,last_modified,last_modified_by
-A00001,P0063,AT01,T00002,1973,1973,"A student was criticized while reading this American textbook in public. Nanchu takes this book as an example, of how volatile the attitude towards studying English was, even/especially (?) at the East China Normal University's Foreign Languages Depar",,T00003,196f,2017-07-12,OS,2017-07-12,OS
-A00002,P0106,AT01,T00004,1972,1976,mentions it among others as an important reading for him and his zhiqing fellows,,T00007,581,2017-07-12,OS,2017-07-12,OS
-A00003,P0017,AT01,T00008,1968,1978,mentions it among others as an important reading for the whole development in the field of literature after 1978,,T00009,219,2017-07-12,OS,2017-07-12,OS
-A00004,P0108,AT01,T00010,1972,1975,Xu Xiao read Ticket to the Stars and was very much influenced by it,,T00012,381,2017-07-12,OS,2017-07-12,OS
-A00005,P0014,AT02,T00010,1972,1975,"Zhao Yifan knew a lot about huangpi and huipi shu, he also copied and distributed them",,T00012,381,2017-07-12,OS,2017-07-12,OS
-A00006,P0014,AT01,P0108,1972,1975,Zhao Yifan handed Ticket to the Stars to Xu Xiao,,T00012,381,2017-07-12,OS,2017-07-12,OS
-A00007,P0109,AT04,T00013,1969,1969,Shu Ting wants to go to Gorky‘s „Universities“ during her rustication,,T00014,300,2017-07-19,LH,2017-07-19,LH
-A00007,P0020,AT04,T00013,1966,1976,"Gao Hua mentions that during the turmoil years of CR, when as a son of ""heiwulei"" (five black categories) he has been living in the bottom of the society, receiving supercilious looks and being discriminated against, these two books by Gorky acted as his spiritual guides.",,T00006,133,2017-07-19,LH,2017-07-19,LH
-A00015,P0009,AT01,T00022,1966,,"They started reading neibu books before rustication time already. Kafka's ""Trial"" was among the most influential neibu books for Bei Dao",,T00011,80,2017-07-19,OS,2017-07-19,OS
-
+act_ID,agent,action,act_object,agens,start,end,substantial_discussion,comment,source_id,page_number,created,created_by,last_modified,last_modified_by
+A00001,P0063,AT01,,T00002,1973,1973,"A student was criticized while reading this American textbook in public. Nanchu takes this book as an example, of how volatile the attitude towards studying English was, even/especially (?) at the East China Normal University's Foreign Languages Depar",,T00003,196f,2017-07-12,OS,2017-07-12,OS
+A00002,P0106,AT01,,T00004,1972,1976,mentions it among others as an important reading for him and his zhiqing fellows,,T00007,581,2017-07-12,OS,2017-07-12,OS
+A00003,P0017,AT01,,T00008,1968,1978,mentions it among others as an important reading for the whole development in the field of literature after 1978,,T00009,219,2017-07-12,OS,2017-07-12,OS
+A00004,P0108,AT01,,T00010,1972,1975,Xu Xiao read Ticket to the Stars and was very much influenced by it,,T00012,381,2017-07-12,OS,2017-07-12,OS
+A00005,P0014,AT02,,T00010,1972,1975,"Zhao Yifan knew a lot about huangpi and huipi shu, he also copied and distributed them",,T00012,381,2017-07-12,OS,2017-07-12,OS
+A00006,P0014,AT01,,P0108,1972,1975,Zhao Yifan handed Ticket to the Stars to Xu Xiao,,T00012,381,2017-07-12,OS,2017-07-12,OS
+A00007,P0109,AT04,,T00013,1969,1969,Shu Ting wants to go to Gorky‘s „Universities“ during her rustication,,T00014,300,2017-07-19,LH,2017-07-19,LH
+A00007,P0020,AT04,,T00013,1966,1976,"Gao Hua mentions that during the turmoil years of CR, when as a son of ""heiwulei"" (five black categories) he has been living in the bottom of the society, receiving supercilious looks and being discriminated against, these two books by Gorky acted as his spiritual guides.",,T00006,133,2017-07-19,LH,2017-07-19,LH
+A00015,P0009,AT01,,T00022,1966,,"They started reading neibu books before rustication time already. Kafka's ""Trial"" was among the most influential neibu books for Bei Dao",,T00011,80,2017-07-19,OS,2017-07-19,OS

--- a/data/Act.csv
+++ b/data/Act.csv
@@ -1,10 +1,9 @@
-act_ID,agent,action,act_object,agens,start,end,substantial_discussion,comment,source_id,page_number,created,created_by,last_modified,last_modified_by
-A00001,P0063,AT01,,T00002,1973,1973,"A student was criticized while reading this American textbook in public. Nanchu takes this book as an example, of how volatile the attitude towards studying English was, even/especially (?) at the East China Normal University's Foreign Languages Depar",,T00003,196f,2017-07-12,OS,2017-07-12,OS
-A00002,P0106,AT01,,T00004,1972,1976,mentions it among others as an important reading for him and his zhiqing fellows,,T00007,581,2017-07-12,OS,2017-07-12,OS
-A00003,P0017,AT01,,T00008,1968,1978,mentions it among others as an important reading for the whole development in the field of literature after 1978,,T00009,219,2017-07-12,OS,2017-07-12,OS
-A00004,P0108,AT01,,T00010,1972,1975,Xu Xiao read Ticket to the Stars and was very much influenced by it,,T00012,381,2017-07-12,OS,2017-07-12,OS
-A00005,P0014,AT02,,T00010,1972,1975,"Zhao Yifan knew a lot about huangpi and huipi shu, he also copied and distributed them",,T00012,381,2017-07-12,OS,2017-07-12,OS
-A00006,P0014,AT01,,P0108,1972,1975,Zhao Yifan handed Ticket to the Stars to Xu Xiao,,T00012,381,2017-07-12,OS,2017-07-12,OS
-A00007,P0109,AT04,,T00013,1969,1969,Shu Ting wants to go to Gorky‘s „Universities“ during her rustication,,T00014,300,2017-07-19,LH,2017-07-19,LH
-A00007,P0020,AT04,,T00013,1966,1976,"Gao Hua mentions that during the turmoil years of CR, when as a son of ""heiwulei"" (five black categories) he has been living in the bottom of the society, receiving supercilious looks and being discriminated against, these two books by Gorky acted as his spiritual guides.",,T00006,133,2017-07-19,LH,2017-07-19,LH
-A00015,P0009,AT01,,T00022,1966,,"They started reading neibu books before rustication time already. Kafka's ""Trial"" was among the most influential neibu books for Bei Dao",,T00011,80,2017-07-19,OS,2017-07-19,OS
+act_ID,agent,action,act_object,act_target,start,end,substantial_discussion,comment,source_id,page_number,created,created_by,last_modified,last_modified_by
+A00001,P0063,AT01,T00002,,1973,1973,"A student was criticized while reading this American textbook in public. Nanchu takes this book as an example, of how volatile the attitude towards studying English was, even/especially (?) at the East China Normal University's Foreign Languages Depar",,T00003,196f,2017-07-12,OS,2017-07-12,OS
+A00002,P0106,AT01,T00004,,1972,1976,mentions it among others as an important reading for him and his zhiqing fellows,,T00007,581,2017-07-12,OS,2017-07-12,OS
+A00003,P0017,AT01,T00008,,1968,1978,mentions it among others as an important reading for the whole development in the field of literature after 1978,,T00009,219,2017-07-12,OS,2017-07-12,OS
+A00004,P0108,AT01,T00010,,1972,1975,Xu Xiao read Ticket to the Stars and was very much influenced by it,,T00012,381,2017-07-12,OS,2017-07-12,OS
+A00005,P0014,AT05,T00010,P0108,1972,1975,"Zhao Yifan copied and handed Ticket to the Stars Xu Xiao. In general Zhao knew a lot about huangpi and huipi shu, he copied and distributed them",,T00012,381,2017-07-12,OS,2017-07-25,OS
+A00007,P0109,AT04,T00013,,1969,1969,Shu Ting wants to go to Gorky‘s „Universities“ during her rustication,,T00014,300,2017-07-19,LH,2017-07-19,LH
+A00007,P0020,AT04,T00013,,1966,1976,"Gao Hua mentions that during the turmoil years of CR, when as a son of ""heiwulei"" (five black categories) he has been living in the bottom of the society, receiving supercilious looks and being discriminated against, these two books by Gorky acted as his spiritual guides.",,T00006,133,2017-07-19,LH,2017-07-19,LH
+A00015,P0009,AT01,T00022,,1966,,"They started reading neibu books before rustication time already. Kafka's ""Trial"" was among the most influential neibu books for Bei Dao",,T00011,80,2017-07-19,OS,2017-07-19,OS

--- a/data/ActType.csv
+++ b/data/ActType.csv
@@ -3,3 +3,4 @@ AT01,to read,2017-07-12,OS,2017-07-12,OS
 AT02,to copy,2017-07-12,OS,2017-07-12,OS
 AT03,to hand over (to sb),2017-07-12,OS,2017-07-12,OS
 AT04,to take as ideal / guide,2017-07-19,LH,2017-07-19,LH
+AT05,to copy and hand over (to sb),2017-07-25,OS,2017-07-25,OS

--- a/data/helper/data_dictionary.csv
+++ b/data/helper/data_dictionary.csv
@@ -98,7 +98,8 @@ ActType,last_modified_by,name of project member last modifying this line,use acr
 Act,act_ID,A and a five-digit number,with leading zeros if necessary,2017-07-04,LH,2017-07-04,LH
 Act,agent,Subject doing something,p.e. person stealing a book use person ID,2017-07-04,LH,2017-07-04,LH
 Act,action,add ActType/action_ID,,2017-07-04,LH,2017-07-04,LH
-Act,agens,Object of an action,p.e. text or person use person or text ID respectively,2017-07-04,LH,2017-07-04,LH
+Act,act_object,Object of an action,,2017-07-25,OS,2017-07-25,OS
+Act,agens,2nd (receiving) person ,p.e. text or person use person or text ID respectively,2017-07-04,LH,2017-07-04,LH
 Act,start,Beginning (year) of an action / we cover reading acts between 1966 and 1981,,2017-07-04,LH,2017-07-04,LH
 Act,end,"End (year) of an action; if only one year / point in time then use same as start year, p.e. 1968-1968",,2017-07-04,LH,2017-07-04,LH
 Act,substantial_discussion,is the activity / text only mentioned briefly (>no) or substantially (>yes),,2017-07-04,LH,2017-07-04,LH

--- a/data/helper/data_dictionary.csv
+++ b/data/helper/data_dictionary.csv
@@ -99,7 +99,7 @@ Act,act_ID,A and a five-digit number,with leading zeros if necessary,2017-07-04,
 Act,agent,Subject doing something,p.e. person stealing a book use person ID,2017-07-04,LH,2017-07-04,LH
 Act,action,add ActType/action_ID,,2017-07-04,LH,2017-07-04,LH
 Act,act_object,Object of an action,use text ID,2017-07-25,OS,2017-07-25,OS
-Act,agens,2nd (receiving) person ,use person ID,2017-07-04,LH,2017-07-04,LH
+Act,act_target,2nd (receiving) person ,use person ID,2017-07-04,LH,2017-07-04,LH
 Act,start,Beginning (year) of an action / we cover reading acts between 1966 and 1981,,2017-07-04,LH,2017-07-04,LH
 Act,end,"End (year) of an action; if only one year / point in time then use same as start year, p.e. 1968-1968",,2017-07-04,LH,2017-07-04,LH
 Act,substantial_discussion,is the activity / text only mentioned briefly (>no) or substantially (>yes),,2017-07-04,LH,2017-07-04,LH

--- a/data/helper/data_dictionary.csv
+++ b/data/helper/data_dictionary.csv
@@ -98,8 +98,8 @@ ActType,last_modified_by,name of project member last modifying this line,use acr
 Act,act_ID,A and a five-digit number,with leading zeros if necessary,2017-07-04,LH,2017-07-04,LH
 Act,agent,Subject doing something,p.e. person stealing a book use person ID,2017-07-04,LH,2017-07-04,LH
 Act,action,add ActType/action_ID,,2017-07-04,LH,2017-07-04,LH
-Act,act_object,Object of an action,,2017-07-25,OS,2017-07-25,OS
-Act,agens,2nd (receiving) person ,p.e. text or person use person or text ID respectively,2017-07-04,LH,2017-07-04,LH
+Act,act_object,Object of an action,use text ID,2017-07-25,OS,2017-07-25,OS
+Act,agens,2nd (receiving) person ,use person ID,2017-07-04,LH,2017-07-04,LH
 Act,start,Beginning (year) of an action / we cover reading acts between 1966 and 1981,,2017-07-04,LH,2017-07-04,LH
 Act,end,"End (year) of an action; if only one year / point in time then use same as start year, p.e. 1968-1968",,2017-07-04,LH,2017-07-04,LH
 Act,substantial_discussion,is the activity / text only mentioned briefly (>no) or substantially (>yes),,2017-07-04,LH,2017-07-04,LH


### PR DESCRIPTION
Person A gives Book X to Person B cannot be reasonably modeled in our model so far. So I have included another column in the act table. 
We have on the other hand often the case that Person A reads Books X, so which column of the two "object columns" shall be used then? We could also call it "Object A" and "Object B", in the end we will only have to be consistent, I guess.